### PR TITLE
Support Ubuntu, and allow lmod package to be installed from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ To customize the avail layout (since Lmod 5.7.5)
 
 The prefix used when lmod was compiled.  Default is '/opt/apps'.
 
+#####`lmod_package_from_repo`
+
+Should the lmod package be installed from a apt/yum repository, or is
+it installed separately with only dependencies installed from package
+repos?
+
 #####`modulepath_root`
 
 The modulepath for your lmod installation.  Default is 'UNSET'.
@@ -91,6 +97,7 @@ Boolean that determines if the packages necessary to build lmod should be manage
 Tested using
 
 * CentOS 6.5
+* Ubuntu 14.04
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 class lmod (
   $prefix                 = $lmod::params::prefix,
+  $lmod_package_from_repo = $lmod::params::lmod_package_from_repo,
   $modulepath_root        = $lmod::params::modulepath_root,
   $modulepaths            = $lmod::params::modulepaths,
   $set_lmod_package_path  = $lmod::params::set_lmod_package_path,
@@ -37,6 +38,7 @@ class lmod (
   validate_bool($set_lmod_package_path)
   validate_bool($set_default_module)
   validate_bool($manage_build_packages)
+  validate_bool($lmod_package_from_repo)
 
   $_modulepath_root = $modulepath_root ? {
     'UNSET' => "${prefix}/modulefiles",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,16 @@ class lmod::params {
       $build_packages = suffix($runtime_packages, '-devel')
     }
 
+    'Debian': {
+      $base_packages = []
+      $runtime_packages = [ 'lmod' ]
+      $build_packages = [
+                         'liblua5.2-dev',
+                         'lua-filesystem-dev',
+                         'lua-posix-dev'
+                         ]
+    }
+
     default: {
       fail("Unsupported osfamily: ${::osfamily}, module ${module_name} only support osfamily RedHat")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,10 +50,10 @@ class lmod::params {
       ]
       $runtime_packages = [ 'lua5.2' ]
       $build_packages = [
-                         'liblua5.2-dev',
-                         'lua-filesystem-dev',
-                         'lua-posix-dev'
-                         ]
+        'liblua5.2-dev',
+        'lua-filesystem-dev',
+        'lua-posix-dev'
+      ]
     }
 
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@
 #
 class lmod::params {
   $prefix                 = '/opt/apps'
+  $lmod_package_from_repo = false
   $modulepath_root        = 'UNSET'
   $modulepaths            = ['$LMOD_sys', 'Core']
   $set_lmod_package_path  = true
@@ -40,8 +41,14 @@ class lmod::params {
     }
 
     'Debian': {
-      $base_packages = []
-      $runtime_packages = [ 'lmod' ]
+      $base_packages = [
+        'lua-filesystem',
+        'lua-json',
+        'lua-posix',
+        'lua-term',
+        'zsh',
+      ]
+      $runtime_packages = [ 'lua5.2' ]
       $build_packages = [
                          'liblua5.2-dev',
                          'lua-filesystem-dev',
@@ -52,6 +59,11 @@ class lmod::params {
     default: {
       fail("Unsupported osfamily: ${::osfamily}, module ${module_name} only support osfamily RedHat")
     }
+  }
+
+  if $lmod_package_from_repo {
+    $base_packages = []
+    $runtime_packages = [ 'lmod' ]
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -20,10 +20,10 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [ "6", "7" ]
-    }
+    },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "14.04" ]
+      "operatingsystemrelease": [ "14.04", "14.10", "15.04" ]
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,10 @@
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [ "6", "7" ]
     }
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [ "14.04" ]
+    }
   ],
   "dependencies": [
     { "name": "puppetlabs-stdlib", "version_requirement": ">= 3.2.0 <5.0.0" },

--- a/spec/classes/lmod_spec.rb
+++ b/spec/classes/lmod_spec.rb
@@ -15,20 +15,21 @@ describe 'lmod' do
 
       describe 'lmod::install' do
         base_packages = [
-          'lua-filesystem',
-          'lua-json',
-          'lua-posix',
-          'lua-term',
-          'zsh',
-        ]
-
-        runtime_packages = [
-          'lua',
-        ]
-
-        build_packages = [
-          'lua-devel',
-        ]
+                         'lua-filesystem',
+                         'lua-json',
+                         'lua-posix',
+                         'lua-term',
+                         'zsh',
+                        ]
+        if facts[:osfamily] == 'RedHat'
+          runtime_packages = [ 'lua' ]
+          build_packages = [ 'lua-devel' ]
+        elsif facts[:osfamily] == 'Debian'
+          runtime_packages = [ 'lua5.2' ]
+          build_packages = [ 'liblua5.2-dev',
+                             'lua-filesystem-dev',
+                             'lua-posix-dev' ]
+        end
 
         if facts[:osfamily] == 'RedHat'
           it { should contain_class('epel') }
@@ -342,6 +343,7 @@ describe 'lmod' do
         :set_lmod_package_path,
         :set_default_module,
         :manage_build_packages,
+        :lmod_package_from_repo,
       ].each do |param|
         context "with #{param} => 'foo'" do
           let(:params) {{ param.to_sym => 'foo' }}


### PR DESCRIPTION
Hi,

this pull request does two things

1) Adds support for Ubuntu (tested on 14.04 with lmod and lua-term packages in private repo, for newer Ubuntu releases lmod and lua-term are found in the default repos).

2) Allows the lmod package to be installed from a apt/yum repo instead of just the dependencies.