### PR TITLE
Use correct default tcsh paths on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Boolean that determines if the packages necessary to build lmod should be manage
 Tested using
 
 * CentOS 6.5
-* Ubuntu 14.04
+* Ubuntu 14.04, 16.04
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@ class lmod (
   $modules_csh_source     = $lmod::params::modules_csh_source,
   $stdenv_bash_template   = $lmod::params::stdenv_bash_template,
   $stdenv_bash_source     = $lmod::params::stdenv_bash_source,
+  $stdenv_csh_path        = $lmod::params::stdenv_csh_path,
   $stdenv_csh_template    = $lmod::params::stdenv_csh_template,
   $stdenv_csh_source      = $lmod::params::stdenv_csh_source,
 ) inherits lmod::params {
@@ -37,6 +38,7 @@ class lmod (
   validate_string($modules_csh_path)
   validate_string($modules_csh_template)
   validate_string($stdenv_bash_template, $stdenv_csh_template)
+  validate_string($stdenv_csh_path)
 
   validate_array($modulepaths)
   validate_array($avail_styles)
@@ -54,7 +56,8 @@ class lmod (
       $_file_ensure = 'absent'
     }
     default: {
-      fail("Module ${module_name}, ensure must be 'present' or 'absent', ${ensure} given.")
+      fail("Module ${module_name}, ensure must be 'present' or 'absent', \
+      ${ensure} given.")
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,7 +31,9 @@ class lmod::install {
   if $lmod::ensure == 'present' {
     ensure_packages($_base_packages, $_package_defaults)
     ensure_packages($_runtime_packages, $_package_defaults)
-    if $lmod::manage_build_packages { ensure_packages($lmod::params::build_packages, $_package_defaults) }
+    if $lmod::manage_build_packages {
+      ensure_packages($lmod::params::build_packages, $_package_defaults)
+    }
   } elsif $lmod::ensure == 'absent' and $lmod::lmod_package_from_repo {
     ensure_packages($_runtime_packages, {'ensure' => 'absent'})
   }

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -59,9 +59,9 @@ class lmod::load {
 
     # Template uses:
     # - $default_module
-    file { '/etc/profile.d/z00_StdEnv.csh':
+    file { 'z00_StdEnv.csh':
       ensure  => $lmod::_file_ensure,
-      path    => '/etc/profile.d/z00_StdEnv.csh',
+      path    => $lmod::stdenv_csh_path,
       content => $lmod::_stdenv_csh_content,
       source  => $lmod::_stdenv_csh_source,
       owner   => 'root',
@@ -73,8 +73,9 @@ class lmod::load {
       ensure  => absent,
     }
 
-    file { '/etc/profile.d/z00_StdEnv.csh':
-      ensure  => absent,
+    file { 'z00_StdEnv.csh':
+      ensure => absent,
+      path   => $lmod::stdenv_csh_path,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,6 @@ class lmod::params {
   $module_bash_path       = '/etc/profile.d/modules.sh'
   $modules_bash_template  = 'lmod/modules.sh.erb'
   $modules_bash_source    = undef
-  $modules_csh_path       = '/etc/profile.d/modules.csh'
   $modules_csh_template   = 'lmod/modules.csh.erb'
   $modules_csh_source     = undef
   $stdenv_bash_template   = 'lmod/z00_StdEnv.sh.erb'
@@ -35,6 +34,8 @@ class lmod::params {
 
   case $::osfamily {
     'RedHat': {
+      $modules_csh_path = '/etc/profile.d/modules.csh'
+      $stdenv_csh_path = '/etc/profile.d/z00_StdEnv.csh'
       $package_name = 'Lmod'
       if $::operatingsystemmajrelease == '5' {
         $base_packages = [
@@ -61,6 +62,8 @@ class lmod::params {
     }
 
     'Debian': {
+      $modules_csh_path = '/etc/csh/login.d/modules.csh'
+      $stdenv_csh_path = '/etc/csh/login.d/z00_StdEnv.csh'
       $package_name = 'lmod'
       if $::operatingsystemmajrelease == '14.04' {
         $base_packages = [
@@ -68,6 +71,7 @@ class lmod::params {
           'lua-json',
           'lua-posix',
           'tcl',
+          'tcsh',
           'zsh',
         ]
       } else {
@@ -77,6 +81,7 @@ class lmod::params {
           'lua-posix',
           'lua-term',
           'tcl',
+          'tcsh',
           'zsh',
         ]
       }
@@ -90,7 +95,8 @@ class lmod::params {
     }
 
     default: {
-      fail("Unsupported osfamily: ${::osfamily}, module ${module_name} only support osfamily RedHat")
+      fail("Unsupported osfamily: ${::osfamily}, module ${module_name} only \
+      support osfamily RedHat or Debian")
     }
   }
 

--- a/spec/acceptance/shared_examples/lmod_install.rb
+++ b/spec/acceptance/shared_examples/lmod_install.rb
@@ -25,6 +25,7 @@ def base_packages
         'lua-json',
         'lua-posix',
         'tcl',
+        'tcsh',
         'zsh',
       ]
     else
@@ -34,6 +35,7 @@ def base_packages
         'lua-posix',
         'lua-term',
         'tcl',
+        'tcsh',
         'zsh',
       ]
     end

--- a/spec/acceptance/shared_examples/lmod_load.rb
+++ b/spec/acceptance/shared_examples/lmod_load.rb
@@ -1,10 +1,24 @@
+def shell_paths
+  case fact('osfamily')
+  when 'Debian'
+    [
+      '/etc/profile.d/modules.sh',
+      '/etc/csh/login.d/modules.csh',
+      '/etc/profile.d/z00_StdEnv.sh',
+      '/etc/csh/login.d/z00_StdEnv.csh',
+    ]
+  else
+    [
+      '/etc/profile.d/modules.sh',
+      '/etc/profile.d/modules.csh',
+      '/etc/profile.d/z00_StdEnv.sh',
+      '/etc/profile.d/z00_StdEnv.csh',
+    ]
+  end
+end
+
 shared_examples_for 'lmod::load' do
-  [
-    '/etc/profile.d/modules.sh',
-    '/etc/profile.d/modules.csh',
-    '/etc/profile.d/z00_StdEnv.sh',
-    '/etc/profile.d/z00_StdEnv.csh',
-  ].each do |file|
+  shell_paths.each do |file|
     describe file(file) do
       it { should be_file }
       it { should be_mode 644 }

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,11 +1,13 @@
-# The baseline for module testing used by Puppet Labs is that each manifest
-# should have a corresponding test manifest that declares that class or defined
-# type.
+# The baseline for module testing used by Puppet Labs is that each
+# manifest should have a corresponding test manifest that declares
+# that class or defined type.
 #
-# Tests are then run by using puppet apply --noop (to check for compilation errors
-# and view a log of events) or by fully applying the test in a virtual environment
-# (to compare the resulting system state to the desired state).
+# Tests are then run by using puppet apply --noop (to check for
+# compilation errors and view a log of events) or by fully applying
+# the test in a virtual environment (to compare the resulting system
+# state to the desired state).
 #
-# Learn more about module testing here: http://docs.puppetlabs.com/guides/tests_smoke.html
+# Learn more about module testing here:
+# http://docs.puppetlabs.com/guides/tests_smoke.html
 #
 include lmod


### PR DESCRIPTION
On Debian derived systems (t)csh doesn't by default read
initialization scripts from /etc/profile.d/ but rather from
/etc/csh/login.d. Thus change to match this, and also change the test
harness to take this into account. Finally, some minor fixes to make
puppet-lint happy.