### PR TITLE
Drop puppet 2.7 testing, sync test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,9 @@ script: bundle exec rake test
 matrix:
   fast_finish: true
   include:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7"
-    - rvm: 1.9.3
+    - rvm: 2.0
       env: PUPPET_GEM_VERSION="~> 3.0"
-    - rvm: 2.1
-      env: PUPPET_GEM_VERSION="~> 3.0"
-    - rvm: 2.1
+    - rvm: 2.0
       env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
     - rvm: 2.1
       env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"


### PR DESCRIPTION
Puppet doesn't support 2.7 anymore, and testing with that release
takes a lot longer than with newer releases,
e.g. https://travis-ci.org/treydock/puppet-lmod/builds/225157773
(30:52 min vs. 6:23 min for the next slowest)

Sync the test matrix with Puppet. For 3.x, ruby 2.0 is the latest
officially supported version,
https://docs.puppet.com/puppet/3.8/system_requirements.html. For
puppet 4.x, ruby 2.1 is currently the only supported version,
https://docs.puppet.com/puppet/4.10/system_requirements.html.

However, for the distro tests, using ruby 2.0 didn't work here due to
nokogiri incompability, so use 2.1 here.