### PR TITLE
Don't hardcode ps/expr/basename paths

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,9 +28,9 @@ class lmod::params {
   $stdenv_csh_template    = 'lmod/z00_StdEnv.csh.erb'
   $stdenv_csh_source      = undef
 
-  $ps_cmd       = '/bin/ps'
-  $expr_cmd     = '/bin/expr'
-  $basename_cmd = '/bin/basename'
+  $ps_cmd       = 'ps'
+  $expr_cmd     = 'expr'
+  $basename_cmd = 'basename'
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
Different distros have these utilities in /bin or /usr/bin. We
shouldn't need to use absolute paths, as they should always be on the
default path.