### PR TITLE
BREAKING Major refactor (read pull request description)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,10 @@ fixtures:
   repositories:
     stdlib:
       repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.13.0
     epel:
-      repo: https://github.com/voxpupuli/puppet-epel
+      repo: https://github.com/voxpupuli/puppet-epel.git
+    archive:
+      repo: https://github.com/voxpupuli/puppet-archive.git
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/.sync.yml
+++ b/.sync.yml
@@ -9,9 +9,6 @@
       - ubuntu-1604
       - ubuntu-1804
       - ubuntu-2004
-  acceptance_excludes:
-    - set: ubuntu-2004
-      puppet: puppet5
 .gitlab-ci.yml:
   delete: true
 appveyor.yml:

--- a/README.md
+++ b/README.md
@@ -11,37 +11,55 @@ The lmod module handles the configuration of a system to use Lmod.  Additional d
 
 ### lmod
 
-The default parameter values are suitable for compute nodes using Lmod.
+Install Lmod through package repositories:
 
-    class { 'lmod': }
+```puppet
+class { 'lmod': }
+```
 
-This is an example of how to configure package building nodes to use Lmod.
+This is an example install Lmod from source.
 
-    class { 'lmod':
-      manage_build_packages => true,
-    }
+```puppet
+class { 'lmod':
+  prefix            => '/apps',
+  moduleroot_path   => '/apps/modulefiles',
+  version           => '8.4.26',
+  install_method    => 'source',
+  source_with_flags => {
+    'spiderCacheDir' => '/apps/lmodcache/cacheDir',
+    'updateSystemFn' => '/apps/lmodcache/system.txt',
+  },
+}
+```
+
+If you wish to manage the Lmod install outside Puppet:
+
+```puppet
+class { 'lmod':
+  prefix            => '/apps',
+  moduleroot_path   => '/apps/modulefiles',
+  install_method    => 'none',
+}
+```
 
 To customize the avail layout (since Lmod 5.7.5)
 
-    class { 'lmod':
-      avail_style => ['grouped', 'system'],
-    }
-
-To install Lmod from existing package repositories
-
-    class { 'lmod':
-      lmod_package_from_repo => true,
-    }
+```puppet
+class { 'lmod':
+  avail_style => ['grouped', 'system'],
+}
+```
 
 Below is an example that adds several paths to default MODULEPATH, sets a default module, sets LMOD\_PACKAGE\_PATH and sets LMOD\_SYSTEM\_NAME.
 
-    class { 'lmod':
-      lmod_package_from_repo => true,
-      modulepaths            => ['$LMOD_sys', 'Core'],
-      set_lmod_package_path  => true,
-      set_default_module     => true,
-      default_module         => 'mycluster',
-    }
+```puppet
+class { 'lmod':
+  modulepaths            => ['$LMOD_sys', 'Core'],
+  set_lmod_package_path  => true,
+  set_default_module     => true,
+  default_module         => 'mycluster',
+}
+```
 
 ## Reference
 
@@ -51,28 +69,6 @@ Below is an example that adds several paths to default MODULEPATH, sets a defaul
 
 Tested using
 
-* CentOS/RedHat 6, 7
-* Ubuntu 14.04, 16.04
-
-## Development
-
-### Testing
-
-Testing requires the following dependencies:
-
-* rake
-* bundler
-
-Install gem dependencies
-
-    bundle install
-
-Run unit tests
-
-    bundle exec rake test
-
-If you have Vagrant >= 1.2.0 installed you can run system tests
-
-    bundle exec rake beaker
-
-## TODO
+* CentOS/RedHat 7, 8
+* Ubuntu 16.04, 18.04, 20.04
+* Debian 9, 10

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,17 +1,14 @@
 ---
 lmod::ensure: 'present'
-lmod::prefix: '/opt/apps'
-lmod::lmod_package_from_repo: false
 lmod::modulepaths:
   - '$LMOD_sys'
   - 'Core'
-lmod::set_lmod_package_path: true
+lmod::set_lmod_package_path: false
 lmod::lmod_package_path: '$MODULEPATH_ROOT/Site'
-lmod::set_default_module: true
+lmod::set_default_module: false
 lmod::default_module: 'StdEnv'
 lmod::avail_styles:
   - 'system'
-lmod::manage_build_packages: false
 lmod::module_bash_path: '/etc/profile.d/modules.sh'
 lmod::modules_bash_template: 'lmod/modules.sh.erb'
 lmod::modules_csh_template: 'lmod/modules.csh.erb'

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,8 +1,13 @@
 ---
-lmod::modules_csh_path: '/etc/csh/login.d/modules.csh'
+lmod::prefix: /usr/share
+lmod::modulepath_root: /usr/modulefiles
+lmod::modules_bash_path: /etc/profile.d/lmod.sh
+lmod::modules_csh_path: '/etc/csh/login.d/lmod.csh'
+lmod::stdenv_bash_path: /etc/profile.d/z00_StdEnv.sh
 lmod::stdenv_csh_path: '/etc/csh/login.d/z00_StdEnv.csh'
 lmod::package_name: 'lmod'
-lmod::base_packages:
+lmod::runtime_packages:
+  - 'lua5.2'
   - 'lua-filesystem'
   - 'lua-json'
   - 'lua-posix'
@@ -10,9 +15,11 @@ lmod::base_packages:
   - 'tcl'
   - 'tcsh'
   - 'zsh'
-lmod::runtime_packages:
-  - 'lua5.2'
 lmod::build_packages:
+  - 'gcc'
+  - 'g++'
+  - 'make'
+  - 'tcl-dev'
   - 'liblua5.2-dev'
   - 'lua-filesystem-dev'
   - 'lua-posix-dev'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,15 +1,22 @@
 ---
+lmod::prefix: /usr/share
+lmod::modulepath_root: /usr/share/modulefiles
+lmod::modules_bash_path: /etc/profile.d/modules.sh
 lmod::modules_csh_path: '/etc/profile.d/modules.csh'
+lmod::stdenv_bash_path: '/etc/profile.d/z00_StdEnv.sh'
 lmod::stdenv_csh_path: '/etc/profile.d/z00_StdEnv.csh'
 lmod::package_name: 'Lmod'
-lmod::base_packages:
+lmod::runtime_packages:
+  - 'lua'
   - 'lua-filesystem'
   - 'lua-json'
   - 'lua-posix'
   - 'lua-term'
   - 'tcl'
   - 'zsh'
-lmod::runtime_packages:
-  - 'lua'
 lmod::build_packages:
+  - 'gcc'
+  - 'gcc-c++'
+  - 'make'
+  - 'tcl-devel'
   - 'lua-devel'

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -1,0 +1,57 @@
+# @summary Install Lmod from source
+# @api private
+class lmod::install::source {
+  assert_private()
+
+  exec { "mkdir-${lmod::source_dir}":
+    path    => '/usr/bin:/bin',
+    command => "mkdir -p ${lmod::source_dir}",
+    creates => $lmod::source_dir,
+  }
+
+  archive { "${lmod::source_dir}/${lmod::version}.tar.gz":
+    source       => "https://github.com/TACC/Lmod/archive/${lmod::version}.tar.gz",
+    extract      => true,
+    extract_path => $lmod::source_dir,
+    creates      => "${lmod::source_dir}/Lmod-${lmod::version}/configure",
+    cleanup      => true,
+    user         => 'root',
+    group        => 'root',
+    require      => Exec["mkdir-${lmod::source_dir}"],
+    before       => File['lmod-configure'],
+  }
+
+  $default_with = delete_undef_values({
+    'siteName' => $lmod::site_name,
+    'module-root-path' => $lmod::modulepath_root,
+  })
+  $with_flags = ($default_with + $lmod::source_with_flags).map |$key, $value| { "--with-${key}='${value}'" }
+  $with = join($with_flags, ' ')
+
+  file { 'lmod-configure':
+    ensure  => 'file',
+    path    => "${lmod::source_dir}/Lmod-${lmod::version}/configure.sh",
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    content => join([
+      '#!/bin/bash',
+      '# File managed by Puppet, do not edit',
+      "./configure --prefix=${lmod::prefix} ${with}",
+      '',
+    ], "\n"),
+  }
+  ~> exec { 'lmod-configure':
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+    command     => "${lmod::source_dir}/Lmod-${lmod::version}/configure.sh",
+    cwd         => "${lmod::source_dir}/Lmod-${lmod::version}",
+    refreshonly => true,
+    logoutput   => true,
+  }
+  ~> exec { 'lmod-make-install':
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+    command     => 'make install',
+    cwd         => "${lmod::source_dir}/Lmod-${lmod::version}",
+    refreshonly => true,
+  }
+}

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -3,8 +3,24 @@
 class lmod::load {
   assert_private()
 
+  # Remove files installed by OS where path maybe different
+  if $facts['os']['family'] == 'RedHat' {
+    if $lmod::modules_bash_path != '/etc/profile.d/00-modulepath.sh' {
+      file { '/etc/profile.d/00-modulepath.sh': ensure => 'absent' }
+    }
+    if $lmod::modules_csh_path != '/etc/profile.d/00-modulepath.csh' {
+      file { '/etc/profile.d/00-modulepath.csh': ensure => 'absent' }
+    }
+    if $lmod::modules_bash_path != '/etc/profile.d/z00_lmod.sh' {
+      file { '/etc/profile.d/z00_lmod.sh': ensure => 'absent' }
+    }
+    if $lmod::modules_csh_path != '/etc/profile.d/z00_lmod.csh' {
+      file { '/etc/profile.d/z00_lmod.csh': ensure => 'absent' }
+    }
+  }
+
   # Template uses:
-  # - $_modulepath_root
+  # - $modulepath_root
   # - $modulepaths
   # - $prefix
   # - $set_lmod_package_path
@@ -24,7 +40,7 @@ class lmod::load {
   }
 
   # Template uses:
-  # - $_modulepath_root
+  # - $modulepath_root
   # - $modulepaths
   # - $prefix
   # - $set_lmod_package_path
@@ -66,7 +82,8 @@ class lmod::load {
     }
   } else {
     file { '/etc/profile.d/z00_StdEnv.sh':
-      ensure  => absent,
+      ensure => absent,
+      path   => $lmod::stdenv_bash_path,
     }
 
     file { 'z00_StdEnv.csh':

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppet/epel",
       "version_requirement": ">= 2.0.0 <4.0.0"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 1.0.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/01_lmod_spec.rb
+++ b/spec/acceptance/01_lmod_spec.rb
@@ -1,31 +1,46 @@
 require 'spec_helper_acceptance'
 
 describe 'lmod class:' do
+  context 'when install_method => "source"' do
+    it 'runs successfully' do
+      pp = <<-EOS
+        class { 'lmod': install_method => 'source' }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it_behaves_like 'lmod::install dependencies'
+    it_behaves_like 'lmod::load'
+    describe command('/bin/bash -l -c "type module"') do
+      its(:stdout) { is_expected.to match %r{LMOD_CMD} }
+    end
+    describe command('/bin/bash -l -c "module load lmod ; which lmod"') do
+      its(:exit_status) { is_expected.to eq(0) }
+    end
+  end
+
   context 'default parameters' do
     it 'runs successfully' do
+      clean_pp = "class { 'lmod': ensure => 'absent' }"
       pp = <<-EOS
         class { 'lmod': }
       EOS
 
+      apply_manifest(clean_pp, catch_failures: true)
+      on hosts, 'rm -rf /usr/share/lmod'
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
 
-    it_behaves_like 'lmod::install without build packages'
+    it_behaves_like 'lmod::install package'
     it_behaves_like 'lmod::load'
-  end
-
-  context 'when manage_build_packages => true' do
-    it 'runs successfully' do
-      pp = <<-EOS
-        class { 'lmod': manage_build_packages => true }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    describe command('/bin/bash -l -c "type module"') do
+      its(:stdout) { is_expected.to match %r{LMOD_CMD} }
     end
-
-    it_behaves_like 'lmod::install with build packages'
-    it_behaves_like 'lmod::load'
+    describe command('/bin/bash -l -c "module load lmod ; which lmod"') do
+      its(:exit_status) { is_expected.to eq(0) }
+    end
   end
 end

--- a/spec/acceptance/shared_examples/lmod_install.rb
+++ b/spec/acceptance/shared_examples/lmod_install.rb
@@ -1,46 +1,8 @@
-def base_packages
-  case fact('osfamily')
-  when 'RedHat'
-    if fact('operatingsystemmajrelease') == '5'
-      [
-        'lua-filesystem',
-        'lua-posix',
-        'tcl',
-        'zsh',
-      ]
-    else
-      [
-        'lua-filesystem',
-        'lua-json',
-        'lua-posix',
-        'lua-term',
-        'tcl',
-        'zsh',
-      ]
-    end
-  when 'Debian'
-    if fact('operatingsystemmajrelease') == '14.04'
-      [
-        'lua-filesystem',
-        'lua-json',
-        'lua-posix',
-        'tcl',
-        'tcsh',
-        'zsh',
-      ]
-    else
-      [
-        'lua-filesystem',
-        'lua-json',
-        'lua-posix',
-        'lua-term',
-        'tcl',
-        'tcsh',
-        'zsh',
-      ]
-    end
+def package_name
+  if fact('osfamily') == 'RedHat'
+    'Lmod'
   else
-    []
+    'lmod'
   end
 end
 
@@ -49,10 +11,23 @@ def runtime_packages
   when 'RedHat'
     [
       'lua',
+      'lua-filesystem',
+      'lua-json',
+      'lua-posix',
+      'lua-term',
+      'tcl',
+      'zsh',
     ]
   when 'Debian'
     [
       'lua5.2',
+      'lua-filesystem',
+      'lua-json',
+      'lua-posix',
+      'lua-term',
+      'tcl',
+      'tcsh',
+      'zsh',
     ]
   else
     []
@@ -63,10 +38,18 @@ def build_packages
   case fact('osfamily')
   when 'RedHat'
     [
+      'gcc',
+      'gcc-c++',
+      'make',
+      'tcl-devel',
       'lua-devel',
     ]
   when 'Debian'
     [
+      'gcc',
+      'g++',
+      'make',
+      'tcl-dev',
       'liblua5.2-dev',
       'lua-filesystem-dev',
       'lua-posix-dev',
@@ -76,33 +59,13 @@ def build_packages
   end
 end
 
-shared_examples_for 'lmod::install without build packages' do
-  base_packages.each do |package|
-    describe package(package) do
-      it { is_expected.to be_installed }
-    end
-  end
-
-  runtime_packages.each do |package|
-    describe package(package) do
-      it { is_expected.to be_installed }
-    end
-  end
-
-  build_packages.each do |package|
-    describe package(package) do
-      it { is_expected.not_to be_installed }
-    end
+shared_examples_for 'lmod::install package' do
+  describe package(package_name) do
+    it { is_expected.to be_installed }
   end
 end
 
-shared_examples_for 'lmod::install with build packages' do
-  base_packages.each do |package|
-    describe package(package) do
-      it { is_expected.to be_installed }
-    end
-  end
-
+shared_examples_for 'lmod::install dependencies' do
   runtime_packages.each do |package|
     describe package(package) do
       it { is_expected.to be_installed }

--- a/spec/acceptance/shared_examples/lmod_load.rb
+++ b/spec/acceptance/shared_examples/lmod_load.rb
@@ -2,17 +2,13 @@ def shell_paths
   case fact('osfamily')
   when 'Debian'
     [
-      '/etc/profile.d/modules.sh',
-      '/etc/csh/login.d/modules.csh',
-      '/etc/profile.d/z00_StdEnv.sh',
-      '/etc/csh/login.d/z00_StdEnv.csh',
+      '/etc/profile.d/lmod.sh',
+      '/etc/csh/login.d/lmod.csh',
     ]
   else
     [
       '/etc/profile.d/modules.sh',
       '/etc/profile.d/modules.csh',
-      '/etc/profile.d/z00_StdEnv.sh',
-      '/etc/profile.d/z00_StdEnv.csh',
     ]
   end
 end

--- a/spec/classes/lmod_spec.rb
+++ b/spec/classes/lmod_spec.rb
@@ -6,9 +6,13 @@ describe 'lmod' do
       let(:facts) { facts }
 
       if facts[:osfamily] == 'Debian'
-        modules_csh_path = '/etc/csh/login.d/modules.csh'
+        modulepath_root = '/usr/modulefiles'
+        moduels_bash_path = '/etc/profile.d/lmod.sh'
+        modules_csh_path = '/etc/csh/login.d/lmod.csh'
         stdenv_csh_path = '/etc/csh/login.d/z00_StdEnv.csh'
       else
+        modulepath_root = '/usr/share/modulefiles'
+        moduels_bash_path = '/etc/profile.d/modules.sh'
         modules_csh_path = '/etc/profile.d/modules.csh'
         stdenv_csh_path = '/etc/profile.d/z00_StdEnv.csh'
       end
@@ -16,15 +20,14 @@ describe 'lmod' do
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to create_class('lmod') }
 
-      it { is_expected.to contain_anchor('lmod::start').that_comes_before('Class[lmod::install]') }
       it { is_expected.to contain_class('lmod::install').that_comes_before('Class[lmod::load]') }
-      it { is_expected.to contain_class('lmod::load').that_comes_before('Anchor[lmod::end]') }
-      it { is_expected.to contain_anchor('lmod::end') }
+      it { is_expected.to contain_class('lmod::load') }
 
       describe 'lmod::install' do
         if facts[:osfamily] == 'RedHat'
           package_require = 'Yumrepo[epel]'
-          base_packages = [
+          runtime_packages = [
+            'lua',
             'lua-filesystem',
             'lua-json',
             'lua-posix',
@@ -33,199 +36,137 @@ describe 'lmod' do
             'zsh',
           ]
           package_name = 'Lmod'
-          runtime_packages = ['lua']
-          build_packages = ['lua-devel']
+          build_packages = ['lua-devel', 'tcl-devel', 'gcc', 'gcc-c++', 'make']
         elsif facts[:osfamily] == 'Debian'
           package_require = nil
-          base_packages = if facts[:operatingsystemmajrelease] == '14.04'
-                            [
-                              'lua-filesystem',
-                              'lua-json',
-                              'lua-posix',
-                              'tcl',
-                              'tcsh',
-                              'zsh',
-                            ]
-                          else
-                            [
-                              'lua-filesystem',
-                              'lua-json',
-                              'lua-posix',
-                              'lua-term',
-                              'tcl',
-                              'tcsh',
-                              'zsh',
-                            ]
-                          end
+          runtime_packages = [
+            'lua5.2',
+            'lua-filesystem',
+            'lua-json',
+            'lua-posix',
+            'lua-term',
+            'tcl',
+            'tcsh',
+            'zsh',
+          ]
           package_name = 'lmod'
-          runtime_packages = ['lua5.2']
           build_packages = ['liblua5.2-dev',
                             'lua-filesystem-dev',
-                            'lua-posix-dev']
+                            'lua-posix-dev',
+                            'tcl-dev',
+                            'gcc',
+                            'g++',
+                            'make']
         end
 
         if facts[:osfamily] == 'RedHat'
           it { is_expected.to contain_class('epel') }
         end
-        it { is_expected.to have_package_resource_count(base_packages.size + runtime_packages.size) }
+        it { is_expected.to have_package_resource_count(1) }
+        it { is_expected.to contain_package(package_name).with_ensure('present').with_require(package_require) }
 
-        (base_packages + runtime_packages).each do |package|
-          it { is_expected.to contain_package(package).with_ensure('present').with_require(package_require) }
+        context "package_ensure => 'latest'" do
+          let(:params) { { package_ensure: 'latest' } }
+
+          it { is_expected.to contain_package(package_name).with_ensure('latest') }
         end
 
-        build_packages.each do |package|
-          it { is_expected.not_to contain_package(package) }
-        end
+        context 'install_method => source' do
+          let(:params) { { install_method: 'source' } }
 
-        context "package_ensure => 'foo'" do
-          let(:params) { { package_ensure: 'foo' } }
-
-          (base_packages + runtime_packages).each do |package|
-            it { is_expected.to contain_package(package).with_ensure('present') }
-          end
-        end
-
-        context 'manage_build_packages => true' do
-          let(:params) { { manage_build_packages: true } }
-
-          it { is_expected.to have_package_resource_count(base_packages.size + runtime_packages.size + build_packages.size) }
-
-          build_packages.each do |package|
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to have_package_resource_count(runtime_packages.size + build_packages.size) }
+          (runtime_packages + build_packages).each do |package|
             it { is_expected.to contain_package(package).with_ensure('present').with_require(package_require) }
           end
-        end
 
-        context 'lmod_package_from_repo => true' do
-          let(:params) { { lmod_package_from_repo: true } }
-
-          it { is_expected.to have_package_resource_count(1) }
-
-          it { is_expected.to contain_package(package_name).with_ensure('present').with_require(package_require) }
-
-          context "package_ensure => 'foo'" do
-            let(:params) { { lmod_package_from_repo: true, package_ensure: 'foo' } }
-
-            it { is_expected.to contain_package(package_name).with_ensure('foo') }
+          it do
+            verify_contents(catalogue, 'lmod-configure', [
+                              "./configure --prefix=/usr/share --with-module-root-path='#{modulepath_root}'",
+                            ])
           end
         end
 
         context 'ensure => absent' do
           let(:params) { { ensure: 'absent' } }
 
-          it { is_expected.to have_package_resource_count(0) }
-        end
-
-        context 'ensure => absent and lmod_package_from_repo => true' do
-          let(:params) { { ensure: 'absent', lmod_package_from_repo: true } }
-
           it { is_expected.to have_package_resource_count(1) }
           it { is_expected.to contain_package(package_name).with_ensure('absent') }
+
+          context 'install_method => source' do
+            let(:params) { { ensure: 'absent', install_method: 'source' } }
+
+            it { is_expected.to have_package_resource_count(0) }
+          end
         end
       end
 
       describe 'lmod::load' do
         it do
-          is_expected.to contain_file('lmod-sh-load').with(ensure: 'present',
-                                                           path: '/etc/profile.d/modules.sh',
-                                                           owner: 'root',
-                                                           group: 'root',
-                                                           mode: '0644')
+          is_expected.to contain_file('lmod-sh-load').with(
+            ensure: 'file',
+            path: moduels_bash_path,
+            owner: 'root',
+            group: 'root',
+            mode: '0644',
+          )
         end
 
         it do
           # Doesn't work exactly like I'd hope due to 'fi' at same indention level occurring more than once
           verify_contents(catalogue, 'lmod-sh-load', [
-                            '    export MODULEPATH_ROOT="/opt/apps/modulefiles"',
-                            '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys)',
-                            '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core)',
-                            '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH /opt/apps/lmod/lmod/modulefiles/Core)',
-                            '    export MODULESHOME=/opt/apps/lmod/lmod',
+                            "    export MODULEPATH_ROOT=\"#{modulepath_root}\"",
+                            '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys)',
+                            '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core)',
+                            '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH /usr/share/lmod/lmod/modulefiles/Core)',
+                            '    export MODULESHOME=/usr/share/lmod/lmod',
                             '    export BASH_ENV=$MODULESHOME/init/bash',
                             '    if [ -z "${MANPATH:-}" ]; then',
                             '      export MANPATH=:',
                             # '    fi',
-                            '    export MANPATH=$(/opt/apps/lmod/lmod/libexec/addto MANPATH /opt/apps/lmod/lmod/share/man)',
-                            '    export LMOD_PACKAGE_PATH=$MODULEPATH_ROOT/Site',
+                            '    export MANPATH=$(/usr/share/lmod/lmod/libexec/addto MANPATH /usr/share/lmod/lmod/share/man)',
                             '    export LMOD_AVAIL_STYLE=system',
                           ])
         end
 
         it do
-          is_expected.to contain_file('lmod-csh-load').with(ensure: 'present',
-                                                            path: modules_csh_path,
-                                                            owner: 'root',
-                                                            group: 'root',
-                                                            mode: '0644')
+          is_expected.to contain_file('lmod-csh-load').with(
+            ensure: 'file',
+            path: modules_csh_path,
+            owner: 'root',
+            group: 'root',
+            mode: '0644',
+          )
         end
 
         it do
           # Doesn't work exactly like I'd hope due to 'endif' at same indention level occurring more than once
           verify_contents(catalogue, 'lmod-csh-load', [
-                            '    setenv MODULEPATH_ROOT      "/opt/apps/modulefiles"',
-                            '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys`',
-                            '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core`',
-                            '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH /opt/apps/lmod/lmod/modulefiles/Core`',
-                            '    setenv MODULESHOME          "/opt/apps/lmod/lmod"',
+                            "    setenv MODULEPATH_ROOT      \"#{modulepath_root}\"",
+                            '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys`',
+                            '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core`',
+                            '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH /usr/share/lmod/lmod/modulefiles/Core`',
+                            '    setenv MODULESHOME          "/usr/share/lmod/lmod"',
                             '    setenv BASH_ENV             "$MODULESHOME/init/bash"',
                             '    if ( ! $?MANPATH ) then',
                             '      setenv MANPATH :',
                             # '    endif',
-                            '    setenv MANPATH `/opt/apps/lmod/lmod/libexec/addto MANPATH /opt/apps/lmod/lmod/share/man`',
-                            '    setenv LMOD_PACKAGE_PATH $MODULEPATH_ROOT/Site',
+                            '    setenv MANPATH `/usr/share/lmod/lmod/libexec/addto MANPATH /usr/share/lmod/lmod/share/man`',
                             '    setenv LMOD_AVAIL_STYLE system',
-                            'if ( -f  /opt/apps/lmod/lmod/init/csh  ) then',
-                            '  source /opt/apps/lmod/lmod/init/csh',
+                            'if ( -f  /usr/share/lmod/lmod/init/csh  ) then',
+                            '  source /usr/share/lmod/lmod/init/csh',
                           ])
         end
 
-        it do
-          is_expected.to contain_file('/etc/profile.d/z00_StdEnv.sh').with(ensure: 'present',
-                                                                           path: '/etc/profile.d/z00_StdEnv.sh',
-                                                                           owner: 'root',
-                                                                           group: 'root',
-                                                                           mode: '0644')
-        end
-
-        it do
-          verify_contents(catalogue, '/etc/profile.d/z00_StdEnv.sh', [
-                            'if [ -z "${USER_IS_ROOT:-}" ]; then',
-                            '  if [ -z "$__Init_Default_Modules" ]; then',
-                            '    export __Init_Default_Modules=1',
-                            '    export LMOD_SYSTEM_DEFAULT_MODULES="StdEnv"',
-                            '    module --initial_load restore',
-                            '  else',
-                            '    module refresh',
-                            '  fi',
-                            'fi',
-                          ])
-        end
-
-        it do
-          is_expected.to contain_file('z00_StdEnv.csh').with(ensure: 'present',
-                                                             path: stdenv_csh_path,
-                                                             owner: 'root',
-                                                             group: 'root',
-                                                             mode: '0644')
-        end
-
-        it do
-          verify_contents(catalogue, 'z00_StdEnv.csh', [
-                            'if ( ! $?__Init_Default_Modules ) then',
-                            '  setenv __Init_Default_Modules 1',
-                            '  setenv LMOD_SYSTEM_DEFAULT_MODULES "StdEnv"',
-                            '  module --initial_load restore',
-                            'else',
-                            '  module refresh',
-                            'endif',
-                          ])
-        end
+        it { is_expected.to contain_file('/etc/profile.d/z00_StdEnv.sh').with_ensure('absent') }
+        it { is_expected.to contain_file('z00_StdEnv.csh').with_ensure('absent') }
 
         context "when prefix => '/apps'" do
           let(:params) { { prefix: '/apps' } }
 
           it do
             verify_contents(catalogue, 'lmod-sh-load', [
-                              '    export MODULEPATH_ROOT="/apps/modulefiles"',
+                              "    export MODULEPATH_ROOT=\"#{modulepath_root}\"",
                               '    export MODULEPATH=$(/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys)',
                               '    export MODULEPATH=$(/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core)',
                               '    export MODULEPATH=$(/apps/lmod/lmod/libexec/addto --append MODULEPATH /apps/lmod/lmod/modulefiles/Core)',
@@ -235,14 +176,13 @@ describe 'lmod' do
                               '      export MANPATH=:',
                               # '    fi',
                               '    export MANPATH=$(/apps/lmod/lmod/libexec/addto MANPATH /apps/lmod/lmod/share/man)',
-                              '    export LMOD_PACKAGE_PATH=$MODULEPATH_ROOT/Site',
                               '    export LMOD_AVAIL_STYLE=system',
                             ])
           end
 
           it do
             verify_contents(catalogue, 'lmod-csh-load', [
-                              '    setenv MODULEPATH_ROOT      "/apps/modulefiles"',
+                              "    setenv MODULEPATH_ROOT      \"#{modulepath_root}\"",
                               '    setenv MODULEPATH           `/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys`',
                               '    setenv MODULEPATH           `/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core`',
                               '    setenv MODULEPATH           `/apps/lmod/lmod/libexec/addto --append MODULEPATH /apps/lmod/lmod/modulefiles/Core`',
@@ -252,7 +192,6 @@ describe 'lmod' do
                               '      setenv MANPATH :',
                               # '    endif',
                               '    setenv MANPATH `/apps/lmod/lmod/libexec/addto MANPATH /apps/lmod/lmod/share/man`',
-                              '    setenv LMOD_PACKAGE_PATH $MODULEPATH_ROOT/Site',
                               '    setenv LMOD_AVAIL_STYLE system',
                               'if ( -f  /apps/lmod/lmod/init/csh  ) then',
                               '  source /apps/lmod/lmod/init/csh',
@@ -265,53 +204,105 @@ describe 'lmod' do
 
           it do
             verify_contents(catalogue, 'lmod-sh-load', [
-                              '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Linux)',
-                              '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core)',
-                              '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Compiler)',
-                              '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/MPI)',
-                              '    export MODULEPATH=$(/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH /opt/apps/lmod/lmod/modulefiles/Core)',
+                              '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Linux)',
+                              '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core)',
+                              '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Compiler)',
+                              '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/MPI)',
+                              '    export MODULEPATH=$(/usr/share/lmod/lmod/libexec/addto --append MODULEPATH /usr/share/lmod/lmod/modulefiles/Core)',
                             ])
           end
 
           it do
             verify_contents(catalogue, 'lmod-csh-load', [
-                              '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Linux`',
-                              '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core`',
-                              '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Compiler`',
-                              '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/MPI`',
-                              '    setenv MODULEPATH           `/opt/apps/lmod/lmod/libexec/addto --append MODULEPATH /opt/apps/lmod/lmod/modulefiles/Core`',
+                              '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Linux`',
+                              '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Core`',
+                              '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/Compiler`',
+                              '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/MPI`',
+                              '    setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH /usr/share/lmod/lmod/modulefiles/Core`',
                             ])
           end
         end
 
-        context 'when set_lmod_package_path => false' do
-          let(:params) { { set_lmod_package_path: false } }
+        context 'when set_lmod_package_path => true' do
+          let(:params) { { set_lmod_package_path: true } }
 
-          it { is_expected.not_to contain_file('lmod-sh-load').with_content(%r{export LMOD_PACKAGE_PATH}) }
-          it { is_expected.not_to contain_file('lmod-csh-load').with_content(%r{setenv LMOD_PACKAGE_PATH}) }
+          it do
+            verify_contents(catalogue, 'lmod-sh-load', [
+                              '    export LMOD_PACKAGE_PATH=$MODULEPATH_ROOT/Site',
+                            ])
+          end
+
+          it do
+            verify_contents(catalogue, 'lmod-csh-load', [
+                              '    setenv LMOD_PACKAGE_PATH $MODULEPATH_ROOT/Site',
+                            ])
+          end
         end
 
-        context "when default_module => 'foo'" do
-          let(:params) { { default_module: 'foo' } }
+        context 'when set_default_module => true' do
+          let(:params) { { set_default_module: true } }
 
-          it 'exports LMOD_SYSTEM_DEFAULT_MODULES="foo"' do
+          it do
+            is_expected.to contain_file('/etc/profile.d/z00_StdEnv.sh').with(
+              ensure: 'file',
+              path: '/etc/profile.d/z00_StdEnv.sh',
+              owner: 'root',
+              group: 'root',
+              mode: '0644',
+            )
+          end
+
+          it do
             verify_contents(catalogue, '/etc/profile.d/z00_StdEnv.sh', [
-                              '    export LMOD_SYSTEM_DEFAULT_MODULES="foo"',
+                              'if [ -z "${USER_IS_ROOT:-}" ]; then',
+                              '  if [ -z "$__Init_Default_Modules" ]; then',
+                              '    export __Init_Default_Modules=1',
+                              '    export LMOD_SYSTEM_DEFAULT_MODULES="StdEnv"',
+                              '    module --initial_load restore',
+                              '  else',
+                              '    module refresh',
+                              '  fi',
+                              'fi',
                             ])
           end
 
-          it 'setenvs LMOD_SYSTEM_DEFAULT_MODULES="foo"' do
+          it do
+            is_expected.to contain_file('z00_StdEnv.csh').with(
+              ensure: 'file',
+              path: stdenv_csh_path,
+              owner: 'root',
+              group: 'root',
+              mode: '0644',
+            )
+          end
+
+          it do
             verify_contents(catalogue, 'z00_StdEnv.csh', [
-                              '  setenv LMOD_SYSTEM_DEFAULT_MODULES "foo"',
+                              'if ( ! $?__Init_Default_Modules ) then',
+                              '  setenv __Init_Default_Modules 1',
+                              '  setenv LMOD_SYSTEM_DEFAULT_MODULES "StdEnv"',
+                              '  module --initial_load restore',
+                              'else',
+                              '  module refresh',
+                              'endif',
                             ])
           end
-        end
 
-        context 'when set_default_module => false' do
-          let(:params) { { set_default_module: false } }
+          context "when default_module => 'foo'" do
+            let(:params) { { set_default_module: true, default_module: 'foo' } }
 
-          it { is_expected.to contain_file('/etc/profile.d/z00_StdEnv.sh').with_ensure('absent') }
-          it { is_expected.to contain_file('z00_StdEnv.csh').with_ensure('absent') }
+            it 'exports LMOD_SYSTEM_DEFAULT_MODULES="foo"' do
+              verify_contents(catalogue, '/etc/profile.d/z00_StdEnv.sh', [
+                                '    export LMOD_SYSTEM_DEFAULT_MODULES="foo"',
+                              ])
+            end
+
+            it 'setenvs LMOD_SYSTEM_DEFAULT_MODULES="foo"' do
+              verify_contents(catalogue, 'z00_StdEnv.csh', [
+                                '  setenv LMOD_SYSTEM_DEFAULT_MODULES "foo"',
+                              ])
+            end
+          end
         end
 
         context "when avail_styles => ['grouped','system']" do
@@ -330,13 +321,13 @@ describe 'lmod' do
           end
         end
 
-        context 'when lmod_admin_file => /opt/apps/lmod/etc/admin.list' do
-          let(:params) { { lmod_admin_file: '/opt/apps/lmod/etc/admin.list' } }
+        context 'when lmod_admin_file => /usr/share/lmod/etc/admin.list' do
+          let(:params) { { lmod_admin_file: '/usr/share/lmod/etc/admin.list' } }
 
           it do
             verify_contents(catalogue, 'lmod-sh-load', [
                               '    export LMOD_AVAIL_STYLE=system',
-                              '    export LMOD_ADMIN_FILE=/opt/apps/lmod/etc/admin.list',
+                              '    export LMOD_ADMIN_FILE=/usr/share/lmod/etc/admin.list',
                               '  fi',
                             ])
           end
@@ -344,7 +335,7 @@ describe 'lmod' do
           it do
             verify_contents(catalogue, 'lmod-csh-load', [
                               '    setenv LMOD_AVAIL_STYLE system',
-                              '    setenv LMOD_ADMIN_FILE /opt/apps/lmod/etc/admin.list',
+                              '    setenv LMOD_ADMIN_FILE /usr/share/lmod/etc/admin.list',
                               'endif',
                             ])
           end

--- a/templates/modules.csh.erb
+++ b/templates/modules.csh.erb
@@ -30,7 +30,7 @@ if ( ! $?MODULEPATH_ROOT ) then
     setenv LMOD_SETTARG_CMD     :
     setenv LMOD_COLORIZE        yes
     setenv LMOD_PREPEND_BLOCK   normal
-    setenv MODULEPATH_ROOT      "<%= scope.lookupvar('lmod::_modulepath_root') %>"
+    setenv MODULEPATH_ROOT      "<%= scope.lookupvar('lmod::modulepath_root') %>"
 <% scope.lookupvar('lmod::modulepaths').each do |modulepath| -%>
     setenv MODULEPATH           `<%= scope.lookupvar('lmod::prefix') %>/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/<%= modulepath %>`
 <% end -%>

--- a/templates/modules.sh.erb
+++ b/templates/modules.sh.erb
@@ -20,7 +20,7 @@ if [ -z "${USER_IS_ROOT:-}" ]; then
     fi
     export LMOD_arch
 
-    export MODULEPATH_ROOT="<%= scope.lookupvar('lmod::_modulepath_root') %>"
+    export MODULEPATH_ROOT="<%= scope.lookupvar('lmod::modulepath_root') %>"
     export LMOD_SETTARG_CMD=":"
     export LMOD_FULL_SETTARG_SUPPORT=no
     export LMOD_COLORIZE=yes


### PR DESCRIPTION
Changes

* Default `prefix` changed to `/usr/share`
* Default `modulepath_root` changed to match OS packages
* Debian based OS path for loading modules environment changed
** Changes `modules_bash_path` and `modules_csh_path`
* Change default `set_lmod_package_path` to `false`
* Change default `set_default_module` to `false`
* Remove `base_packages` parameter, moved to `runtime_packages`
* Remove `lmod_package_from_repo` parameter, replaced by `install_method` parameter
* Remove `manage_build_packages` parameter (set `build_packages` to empty array to get same behavior as before)

New features

* Support installing from source